### PR TITLE
Catch spawnSync ENOENT error

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -21,7 +21,7 @@ class HindentFormatEditsProvider implements
 
         if (this.enable) {
             let result = child_process.spawnSync(this.command, ['--version']);
-            if (!result.status) {
+            if (!result.error) {
                 this.hindentAvailable = true;
 
                 console.log("hindent-format: using executable: " + this.command);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -27,7 +27,7 @@ class HindentFormatEditsProvider implements
                 console.log("hindent-format: using executable: " + this.command);
             } else {
                 this.hindentAvailable = false;
-                vscode.window.showWarningMessage("hindent-format: cannot execute hindent command: " + this.command);
+                this.catchExecError(result.error);
             }
         }
     }
@@ -42,12 +42,7 @@ class HindentFormatEditsProvider implements
         let result = child_process.spawnSync(this.command, this.arguments, { cwd: cwd, input: text });
 
         if (result.error) {
-            let error = <NodeJS.ErrnoException>result.error;
-            let message = error.message;
-            if (error.code === "ENOENT") {
-                message = "Could not locate hindent. Try specifying the hindent-format.command setting?";
-            }
-            vscode.window.showErrorMessage(message);
+            this.catchExecError(result.error);
             return '';
         }
 
@@ -84,6 +79,14 @@ class HindentFormatEditsProvider implements
         } else {
             return [];
         }
+    }
+
+    catchExecError(error: NodeJS.ErrnoException) {
+        let message = error.message;
+        if (error.code === "ENOENT") {
+            message = `hindent-format: Could not execute ${this.command}. Try specifying the hindent-format.command setting?`;
+        }
+        vscode.window.showErrorMessage(message);
     }
 }
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -39,11 +39,18 @@ class HindentFormatEditsProvider implements
             let documentPath = vscode.window.activeTextEditor.document.uri.fsPath;
             cwd = path.dirname(documentPath);
         }
-        let result = child_process.spawnSync(
-            this.command, this.arguments, {
-                'cwd': cwd
-                , 'input': text
-            });
+        let result = child_process.spawnSync(this.command, this.arguments, { cwd: cwd, input: text });
+
+        if (result.error) {
+            let error = <NodeJS.ErrnoException>result.error;
+            let message = error.message;
+            if (error.code === "ENOENT") {
+                message = "Could not locate hindent. Try specifying the hindent-format.command setting?";
+            }
+            vscode.window.showErrorMessage(message);
+            return '';
+        }
+
         if (!result.status) {
             return result.stdout.toString();
         } else {


### PR DESCRIPTION
Fixes #8, which was due to VS Code not being able to locate the `hindent` binary. I added an informative error message to inform the user to explicitly specify the `hindent-format.command` setting, which would resolve the issue once I put the full path of `hindent` in the settings file.

Although the `hindent` binary is located in my `$PATH`, VS Code does not seem to be able to find it. The same issue happens with `hlint` as well.